### PR TITLE
renames repo in documentation to cast-ui

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # TKXS Component Library
 
-[Component Documentation](https://technekes.github.io/component-library/)
+[Component Documentation](https://technekes.github.io/cast-ui/)
 
 ## Usage
 
@@ -25,7 +25,7 @@ included with CommonJS and ES5 modules.
 ### Components
 
 Components in this library must receive a theme object as
-[documented](https://technekes.github.io/component-library/). To achieve this,
+[documented](https://technekes.github.io/cast-ui/). To achieve this,
 use the `ThemeProvider`, which is passed on from
 [styled-components](https://www.styled-components.com/docs/advanced#theming).
 If no theme is provided, components will fall back to a default theme.

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/technekes/component-library"
+    "url": "https://github.com/technekes/cast-ui"
   },
   "scripts": {
     "start": "webpack-dev-server --open --config webpack.dev.js",


### PR DESCRIPTION
To be coupled with renaming this repo to `cast-ui`. Please also remove "Code name: Skull" from the repo description.

@johnallen3d @mgeitz 