### PR TITLE
Restrict border radius changes to select input

### DIFF
--- a/src/Select/Select.component.tsx
+++ b/src/Select/Select.component.tsx
@@ -149,7 +149,7 @@ const SDiv = styled.div<Props>`
   font-family: ${(props: Props) => props.theme.typography.fontFamily};
   font-size: ${(props: Props) => props.theme.common[props.selectSize!].fontSize}
   color: ${(props: Props) => props.theme.reverseText};
-  .react-select-component > div {
+  .react-select-component > div[class*="-control"] {
     min-height: unset;
     margin-top: 1px;
     padding-top: 1px;
@@ -157,7 +157,7 @@ const SDiv = styled.div<Props>`
       props.borderRadius || props.theme.common[props.selectSize!].borderRadius};
     border-color: ${(props: Props) =>
       props.borderColor || props.theme.select.borderColor || 'inherit'};
-  }
+	}
 `;
 
 const SSelect = styled(Select)`

--- a/src/Select/Select.component.tsx
+++ b/src/Select/Select.component.tsx
@@ -63,7 +63,7 @@ export interface Props extends React.HTMLAttributes<HTMLDivElement> {
    *
    * @default null
    **/
-  selectedOption?: string;
+  selectedOption?: Object | Object[];
   /**
    * Any props that should be passed directly to the third-
    * party react-select control.

--- a/src/Select/Select.stories.tsx
+++ b/src/Select/Select.stories.tsx
@@ -19,6 +19,7 @@ storiesOf('Select', module).add(
         borderColor={text('borderColor', '')}
         borderRadius={text('borderRadius', '')}
         onChange={action('onChange')}
+        selectedOption={{ value: 'vanilla', label: 'Vanilla' }}
         options={[
           { value: 'chocolate', label: 'Chocolate' },
           { value: 'strawberry', label: 'Strawberry' },
@@ -30,9 +31,19 @@ storiesOf('Select', module).add(
   {
     info: {
       text: `
-        ### Notes
+### Notes
 
-        This is a Select, based on the react-select component
+This is a Select, based on the [react-select](https://github.com/JedWatson/react-select) library.
+
+###### Important
+
+The version of **react-select** used is **version 2** and it introduces a number of changes from version 1.
+
+For example, the *selectedOption* prop cannot accept any simple values such as strings.
+
+The recommended implementation can be found [here](https://react-select.com/upgrade-guide#simple-value)
+
+Review the [upgrade guide](https://react-select.com/upgrade-guide) on what to expect if coming from version 1.
         `,
     },
   },


### PR DESCRIPTION
Addresses 
- `selectedOption` type on issue #223 
- `borderRadius` restriction on issue #230 

@ben-dalton 

The `onChange` function for the `Select` component is under the `controlSpecificProps` props