### PR TITLE
Conditionally Render PanelHeader Colon

### DIFF
--- a/src/Panel/PanelHeader.component.tsx
+++ b/src/Panel/PanelHeader.component.tsx
@@ -148,7 +148,7 @@ export class PanelHeader extends React.Component<Props> {
     return (
       <ThemeProvider theme={(outerTheme: any) => outerTheme || theme}>
         <SPanelHeader onClick={(e: any) => toggleItem!(e, theme)} {...props}>
-          {name && <b>{name}:</b>} {title}{' '}
+          {name && <b>{name}{title ? ':' : ''}</b>} {title}{' '}
           {ChevronImage(this.props.isCollapsed)}
         </SPanelHeader>
       </ThemeProvider>


### PR DESCRIPTION
A small change to render the `PanelHeader`'s colon only if there's a `title` following it. This way, setting a `name` without a `title` won't have a trailing colon.