### PR TITLE
Allow any react-select props to pass down

### DIFF
--- a/src/Select/Select.component.tsx
+++ b/src/Select/Select.component.tsx
@@ -94,52 +94,53 @@ export interface Props extends React.HTMLAttributes<HTMLDivElement> {
    *
    * @default null
    **/
-  controlSpecificProps?: {
-    blockOptionHover: boolean;
-    clearFocusValueOnUpdate: boolean;
-    commonProps: any;
-    // components: SelectComponents<OptionType>;
-    hasGroups: boolean;
-    initialTouchX: number;
-    initialTouchY: number;
-    inputIsHiddenAfterUpdate: boolean | null;
-    instancePrefix: string;
-    isSearchable: boolean;
-    name: string;
-    openAfterFocus: boolean;
-    scrollToFocusedOptionOnUpdate: boolean;
-    userIsDragging: boolean | null;
-    controlRef: React.Ref<any>;
-    getControlRef: (ref: HTMLElement) => void;
-    focusedOptionRef: React.Ref<any>;
-    getFocusedOptionRef: (ref: HTMLElement) => void;
-    menuListRef: React.Ref<any>;
-    getMenuListRef: (ref: HTMLElement) => void;
-    inputRef: React.Ref<any>;
-    getInputRef: (ref: HTMLElement) => void;
-    // cacheComponents: (components: SelectComponents<OptionType>) => void;
-    onMenuOpen(): void;
-    onMenuClose(): void;
-    // onInputChange(newValue: string, actionMeta: InputActionMeta): void;
-    focusInput(): void;
-    blurInput(): void;
-    focus(): void;
-    blur(): void;
-    openMenu(focusOption: 'first' | 'last'): void;
-    focusValue(direction: 'previous' | 'next'): void;
-    menuPlacement: 'auto' | 'top' | 'bottom';
-    // focusOption(direction: FocusDirection): void;
-    // setValue: (
-    //   newValue: ValueType<OptionType>,
-    //   action: ActionTypes,
-    //   option?: OptionType
-    // ) => void;
-    selectOption: (newValue: OptionType) => void;
-    removeValue: (removedValue: OptionType) => void;
-    clearValue: () => void;
-    popValue: () => void;
-    children: React.ReactElement;
-  };
+  controlSpecificProps?: any;
+  //  {
+  //   blockOptionHover: boolean;
+  //   clearFocusValueOnUpdate: boolean;
+  //   commonProps: any;
+  //   // components: SelectComponents<OptionType>;
+  //   hasGroups: boolean;
+  //   initialTouchX: number;
+  //   initialTouchY: number;
+  //   inputIsHiddenAfterUpdate: boolean | null;
+  //   instancePrefix: string;
+  //   isSearchable: boolean;
+  //   name: string;
+  //   openAfterFocus: boolean;
+  //   scrollToFocusedOptionOnUpdate: boolean;
+  //   userIsDragging: boolean | null;
+  //   controlRef: React.Ref<any>;
+  //   getControlRef: (ref: HTMLElement) => void;
+  //   focusedOptionRef: React.Ref<any>;
+  //   getFocusedOptionRef: (ref: HTMLElement) => void;
+  //   menuListRef: React.Ref<any>;
+  //   getMenuListRef: (ref: HTMLElement) => void;
+  //   inputRef: React.Ref<any>;
+  //   getInputRef: (ref: HTMLElement) => void;
+  //   // cacheComponents: (components: SelectComponents<OptionType>) => void;
+  //   onMenuOpen(): void;
+  //   onMenuClose(): void;
+  //   // onInputChange(newValue: string, actionMeta: InputActionMeta): void;
+  //   focusInput(): void;
+  //   blurInput(): void;
+  //   focus(): void;
+  //   blur(): void;
+  //   openMenu(focusOption: 'first' | 'last'): void;
+  //   focusValue(direction: 'previous' | 'next'): void;
+  //   menuPlacement: 'auto' | 'top' | 'bottom';
+  //   // focusOption(direction: FocusDirection): void;
+  //   // setValue: (
+  //   //   newValue: ValueType<OptionType>,
+  //   //   action: ActionTypes,
+  //   //   option?: OptionType
+  //   // ) => void;
+  //   selectOption: (newValue: OptionType) => void;
+  //   removeValue: (removedValue: OptionType) => void;
+  //   clearValue: () => void;
+  //   popValue: () => void;
+  //   children: React.ReactElement;
+  // };
   /**
    * Color of the input's border
    *

--- a/src/Select/Select.component.tsx
+++ b/src/Select/Select.component.tsx
@@ -127,6 +127,7 @@ export interface Props extends React.HTMLAttributes<HTMLDivElement> {
     blur(): void;
     openMenu(focusOption: 'first' | 'last'): void;
     focusValue(direction: 'previous' | 'next'): void;
+    menuPlacement: 'auto' | 'top' | 'bottom';
     // focusOption(direction: FocusDirection): void;
     // setValue: (
     //   newValue: ValueType<OptionType>,


### PR DESCRIPTION
Removing these definitions for now. We need to be able to pass any of the `react-select` props to the underlying component.