### PR TITLE
Build All Branches

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -45,7 +45,7 @@ jobs:
           paths:
             - *cache_path_git
 
-  lint:
+  build_lint:
     docker:
       - image: *image_node
     working_directory: /usr/src/app
@@ -55,23 +55,27 @@ jobs:
           name: Install
           command: npm install
       - run:
+          name: Build
+          command: npm run build
+      - run:
           name: Lint
           command: npm run lint
+      - save_cache:
+          key: *cache_key_git
+          paths:
+            - *cache_path_git
       - save_cache:
           key: *cache_key_npm
           paths:
             - *cache_path_npm
 
-  build_and_deploy:
+  deploy:
     docker:
       - image: *image_node
     working_directory: /usr/src/app
     steps:
       - *restore_cache_git
       - *restore_cache_npm
-      - run:
-          name: Build
-          command: npm run build
       - run:
           name: Deploy
           command: npm run deploy-storybook && npm publish
@@ -81,12 +85,12 @@ workflows:
   lint_and_deploy:
     jobs:
       - checkout_code
-      - lint:
+      - build_lint:
           requires:
             - checkout_code
-      - build_and_deploy:
+      - deploy:
           requires:
-            - lint
+            - build_lint
           filters:
             branches:
               only: /(^env/production)/


### PR DESCRIPTION
- All branches are built, build assets cached to avoid a rebuild
when deploying `env/production`