### PR TITLE
Correct CI Builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -61,21 +61,20 @@ jobs:
           name: Lint
           command: npm run lint
       - save_cache:
-          key: *cache_key_git
-          paths:
-            - *cache_path_git
-      - save_cache:
           key: *cache_key_npm
           paths:
             - *cache_path_npm
 
-  deploy:
+  build_deploy:
     docker:
       - image: *image_node
     working_directory: /usr/src/app
     steps:
       - *restore_cache_git
       - *restore_cache_npm
+      - run:
+          name: Build
+          command: npm run build
       - run:
           name: Deploy
           command: npm run deploy-storybook && npm publish
@@ -88,7 +87,7 @@ workflows:
       - build_lint:
           requires:
             - checkout_code
-      - deploy:
+      - build_deploy:
           requires:
             - build_lint
           filters:


### PR DESCRIPTION
- Caching the project root folder does not appear to capture build
assets required for npm pack