### PR TITLE
Move static Table props to defaultProps

### DIFF
--- a/src/Table/Table.component.tsx
+++ b/src/Table/Table.component.tsx
@@ -204,15 +204,17 @@ export class Table extends React.Component<Props> {
     striped: false,
     tableSize: 'md',
     theme: Themes.defaultTheme,
+    minRows: 0,
+    pageSize: 10,
+    PaginationComponent: TablePagination,
+    nextText: 'Next >',
+    previousText: '< Previous',
   };
-
   render() {
     const { data, theme, getTrProps, getTdProps, ...props } = this.props;
     return (
       <ThemeProvider theme={(outerTheme: any) => outerTheme || theme}>
         <SWrapperDiv
-          minRows={0}
-          pageSize={10}
           showPagination={data.length > 0}
           data={data}
           defaultSortMethod={collator.compare}
@@ -245,9 +247,6 @@ export class Table extends React.Component<Props> {
               className,
             };
           }}
-          PaginationComponent={TablePagination}
-          nextText="Next >"
-          previousText="< Previous"
           {...props}
         />
       </ThemeProvider>


### PR DESCRIPTION
Props added directly were being overridden by React Tables default props so they have been moved to `defaultProps` for the component to avoid that while maintaining flexibility 