### PR TITLE
CCIBI-321 IE11: Datepicker don't opening if one of the dates is disabled

### DIFF
--- a/src/DatePickerRange/DatePickerRange.component.tsx
+++ b/src/DatePickerRange/DatePickerRange.component.tsx
@@ -220,6 +220,7 @@ export class DatePickerRange extends React.PureComponent<Props> {
       invalid,
       invalidText,
       invalidTextColor,
+      disabled,
       ...props
     } = this.props;
     const errorId = invalid ? `${id}-error-msg` : '';
@@ -244,6 +245,7 @@ export class DatePickerRange extends React.PureComponent<Props> {
             onFocusChange={this.onFocusChange}
             onDatesChange={this.onDatesChange}
             showDefaultInputIcon={true}
+            disabled={disabled}
             {...props}
           />
           {invalid && (


### PR DESCRIPTION
Do not provide disabled attr to wrapping div element