### PR TITLE
CCIBI-432 Edge and IE11 have scrollbar in Distributor Selection Modal…

### DIFF
--- a/src/Table/Table.component.tsx
+++ b/src/Table/Table.component.tsx
@@ -192,6 +192,8 @@ const SWrapperDiv = styled(ReactTable)`
     top: 10px;
     height: 100px;
     background-color: ${(props: any) => props.theme.colors.secondaryBackground};
+    transform: none;
+    left: 0;
   }
 
   &.ReactTable .white-space-wrap {


### PR DESCRIPTION
… when no rows returned

Do not use transform and left position due to incorrect width calculation in IE