### PR TITLE
CCIBI-369 - Add page size options to TablePagination component

### DIFF
--- a/src/Table/Table.component.tsx
+++ b/src/Table/Table.component.tsx
@@ -30,6 +30,12 @@ export type Props = Partial<TableProps> &
      **/
     sizable?: boolean;
     /**
+     * Specify if table page size option is available
+     *
+     * @default true
+     **/
+    showPageSizeOptions?: boolean;
+    /**
      * From theme provider
      *
      * @default defaultTheme
@@ -232,13 +238,14 @@ export class Table extends React.Component<Props> {
     tableSize: 'md',
     theme: Themes.defaultTheme,
     minRows: 0,
-    pageSize: 10,
+    defaultPageSize: 10,
     resizable: false,
     PaginationComponent: TablePagination,
     nextText: 'Next >',
     previousText: '< Previous',
     getTdProps: ReactTableDefaults.getTdProps,
     getTrProps: ReactTableDefaults.getTrProps,
+    showPageSizeOptions: true,
   };
   render() {
     const { data, getTdProps, getTrProps, theme, ...props } = this.props;

--- a/src/TablePagination/TablePagination.component.tsx
+++ b/src/TablePagination/TablePagination.component.tsx
@@ -3,6 +3,7 @@ import styled, { ThemeProvider } from 'styled-components';
 import SPaginationButton from './SPaginationButton';
 import SPaginationButtonNextPrev from './SPaginationButtonNextPrev';
 import { Themes } from '../themes';
+import Select from '../Select/Select.component';
 
 export interface Props extends React.HTMLAttributes<HTMLDivElement> {
   /**
@@ -59,7 +60,7 @@ export interface Props extends React.HTMLAttributes<HTMLDivElement> {
   onFetchData?: () => {};
   showPageSizeOptions?: boolean;
   pageSize?: number;
-  pageSizeOptions?: [];
+  pageSizeOptions: [];
   rowsSelectorText?: string;
   rowsText?: string;
 }
@@ -77,6 +78,11 @@ const SDivPaginationWrapper = styled.div`
 
 const SDivPaginationSectionWrapper = styled.div`
   display: inline-block;
+`;
+
+const SSpanPageSizeOptionsSelectWrapper = styled.span`
+  display: inline-block;
+  min-width: 120px;
 `;
 
 export class TablePagination extends React.Component<Props> {
@@ -98,6 +104,7 @@ export class TablePagination extends React.Component<Props> {
     rowsSelectorText: '',
     rowsText: '',
     pageSizeOptions: [5, 10, 20, 25, 50, 100],
+    pageSize: 10,
   };
 
   componentWillReceiveProps(nextProps: Props) {
@@ -155,22 +162,35 @@ export class TablePagination extends React.Component<Props> {
     pageSizeOptions,
     rowsSelectorText,
     rowsText,
-  }) => (
-    <span className="select-wrap -pageSizeOptions">
-      <select
-        aria-label={rowsSelectorText}
-        onChange={e => this.changePageSize(Number(e.target.value))}
-        value={pageSize}
-      >
-        {pageSizeOptions.map((option, i) => (
-          // eslint-disable-next-line react/no-array-index-key
-          <option key={i} value={option}>
-            {`${option} ${rowsText}`}
-          </option>
-        ))}
-      </select>
-    </span>
-  );
+  }) => {
+    const options = pageSizeOptions.map((option, i) => ({
+      label: `${option} ${rowsText}`,
+      value: i,
+    }));
+    return (
+      <SSpanPageSizeOptionsSelectWrapper className="select-wrap -pageSizeOptions">
+        <Select
+          id="tablePaginationRows"
+          isMulti={false}
+          isDisabled={this.props.pages <= 0}
+          selectSize="sm"
+          onChange={selectedOption =>
+            this.changePageSize(
+              Number(this.props.pageSizeOptions[selectedOption.value]),
+            )
+          }
+          closeMenuOnSelect={true}
+          options={options}
+          controlSpecificProps={{
+            isSearchable: false,
+            defaultValue: { label: '10 rows', value: 1 },
+            'aria-label': { rowsSelectorText },
+          }}
+        />
+      </SSpanPageSizeOptionsSelectWrapper>
+    );
+  };
+
   render() {
     const {
       theme,

--- a/src/TablePagination/TablePagination.component.tsx
+++ b/src/TablePagination/TablePagination.component.tsx
@@ -84,6 +84,7 @@ export class TablePagination extends React.Component<Props> {
     super(props);
 
     this.changePage = this.changePage.bind(this);
+    this.changePageSize = this.changePageSize.bind(this);
 
     this.state = {
       visiblePages: this.getVisiblePages(0, props.pages),
@@ -143,17 +144,22 @@ export class TablePagination extends React.Component<Props> {
     this.props.onPageChange!(page - 1);
   }
 
+  changePageSize(pageSize: number, page?: number) {
+    if (this.props.onPageSizeChange) {
+      this.props.onPageSizeChange(pageSize);
+    }
+  }
+
   renderPageSizeOptions = ({
     pageSize,
     pageSizeOptions,
     rowsSelectorText,
-    onPageSizeChange,
     rowsText,
   }) => (
     <span className="select-wrap -pageSizeOptions">
       <select
         aria-label={rowsSelectorText}
-        onChange={e => onPageSizeChange(Number(e.target.value))}
+        onChange={e => this.changePageSize(Number(e.target.value))}
         value={pageSize}
       >
         {pageSizeOptions.map((option, i) => (
@@ -188,7 +194,6 @@ export class TablePagination extends React.Component<Props> {
             this.renderPageSizeOptions({
               pageSize,
               pageSizeOptions,
-              onPageSizeChange,
               rowsSelectorText: this.props.rowsSelectorText,
               rowsText: this.props.rowsText,
             })}

--- a/src/TablePagination/TablePagination.component.tsx
+++ b/src/TablePagination/TablePagination.component.tsx
@@ -52,11 +52,16 @@ export interface Props extends React.HTMLAttributes<HTMLDivElement> {
   /**
    * From table props
    */
-  onPageSizeChange?: () => {};
+  onPageSizeChange?(pageSize: number, page?: number): any;
   /**
    * From table props
    */
   onFetchData?: () => {};
+  showPageSizeOptions?: boolean;
+  pageSize?: number;
+  pageSizeOptions?: [];
+  rowsSelectorText?: string;
+  rowsText?: string;
 }
 
 const initialState = {
@@ -88,6 +93,10 @@ export class TablePagination extends React.Component<Props> {
 
   static defaultProps = {
     theme: Themes.defaultTheme,
+    showPageSizeOptions: false,
+    rowsSelectorText: '',
+    rowsText: '',
+    pageSizeOptions: [5, 10, 20, 25, 50, 100],
   };
 
   componentWillReceiveProps(nextProps: Props) {
@@ -134,12 +143,37 @@ export class TablePagination extends React.Component<Props> {
     this.props.onPageChange!(page - 1);
   }
 
+  renderPageSizeOptions = ({
+    pageSize,
+    pageSizeOptions,
+    rowsSelectorText,
+    onPageSizeChange,
+    rowsText,
+  }) => (
+    <span className="select-wrap -pageSizeOptions">
+      <select
+        aria-label={rowsSelectorText}
+        onChange={e => onPageSizeChange(Number(e.target.value))}
+        value={pageSize}
+      >
+        {pageSizeOptions.map((option, i) => (
+          // eslint-disable-next-line react/no-array-index-key
+          <option key={i} value={option}>
+            {`${option} ${rowsText}`}
+          </option>
+        ))}
+      </select>
+    </span>
+  );
   render() {
     const {
       theme,
       onFetchData,
       onPageSizeChange,
       onPageChange,
+      pageSize,
+      showPageSizeOptions,
+      pageSizeOptions,
       PageButtonComponent = SPaginationButton,
       PageButtonNextPrevComponent = SPaginationButtonNextPrev,
       ...props
@@ -150,6 +184,14 @@ export class TablePagination extends React.Component<Props> {
     return (
       <ThemeProvider theme={(outerTheme: any) => outerTheme || theme}>
         <SDivPaginationWrapper {...props}>
+          {showPageSizeOptions &&
+            this.renderPageSizeOptions({
+              pageSize,
+              pageSizeOptions,
+              onPageSizeChange,
+              rowsSelectorText: this.props.rowsSelectorText,
+              rowsText: this.props.rowsText,
+            })}
           <SDivPaginationSectionWrapper>
             <PageButtonNextPrevComponent
               btnSize="md"

--- a/src/TablePagination/TablePagination.stories.tsx
+++ b/src/TablePagination/TablePagination.stories.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { storiesOf } from '@storybook/react';
-import { number, select, text } from '@storybook/addon-knobs/react';
+import { number, select, text, boolean } from '@storybook/addon-knobs/react';
 import { action } from '@storybook/addon-actions';
 import { TablePagination } from '../';
 import SPaginationButton from './SPaginationButton';
@@ -19,6 +19,8 @@ storiesOf('Table', module).add(
         PageButtonComponent={SPaginationButton}
         PageButtonNextPrevComponent={SPaginationButtonNextPrev}
         previousText={text('previousText', 'Previous')}
+        showPageSizeOptions={boolean('showPageSizeOptions', true)}
+        onPageSizeChange={action('Page Size changed')}
       />
     );
   },


### PR DESCRIPTION
[CCIBI-369](https://technekes.atlassian.net/browse/CCIBI-369)

This adds the **results per page** or **page size options** drop down option and can be activated with the `showPageSizeOptions` boolean prop similar to the way `react-table` does it.

@ben-dalton @tdakhla