### PR TITLE
Add high value z-index to menu

### DIFF
--- a/src/Select/Select.component.tsx
+++ b/src/Select/Select.component.tsx
@@ -364,6 +364,7 @@ export class CustomSelect extends React.Component<Props> {
               menuPortal: styles => ({
                 ...styles,
                 fontFamily: theme.typography.fontFamily,
+                zIndex: 9999,
               }),
             }}
             {...props}


### PR DESCRIPTION
[CCIBI-369](https://technekes.atlassian.net/browse/CCIBI-369)

- fixes the issue of the `Select` drop menu not being visible on modals