### PR TITLE
Set visible pages correctly when changing pages.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Next Release
 
-- Your contribution here.
+- [#524](https://github.com/technekes/cast-ui/pull/524): Fix pagination buttons - [@abrandontkxs](https://github.com/abrandontkxs)
 
 # 0.4.9 (2019-12-06)
 

--- a/src/Pagination/Pagination.component.tsx
+++ b/src/Pagination/Pagination.component.tsx
@@ -228,7 +228,7 @@ export class Pagination extends React.Component<Props> {
               onClick={() => {
                 this.changePage(activePage - 1);
               }}
-              disabled={activePage === 1}
+              disabled={activePage === 1 || this.props.pages === 0}
             >
               {this.props.previousText}
             </PageButtonNextPrevComponent>

--- a/src/Pagination/Pagination.component.tsx
+++ b/src/Pagination/Pagination.component.tsx
@@ -106,14 +106,19 @@ export class Pagination extends React.Component<Props> {
   };
 
   componentWillReceiveProps(nextProps: Props) {
-    if (this.props.pages !== nextProps.pages) {
-      this.setState({
-        activePage: 1,
-        visiblePages: this.getVisiblePages(0, nextProps.pages),
-      });
-    }
+    const nextActivePage = nextProps.page + 1;
+    const nextVisiblePages = this.getVisiblePages(
+      nextActivePage,
+      nextProps.pages,
+    );
 
-    this.changePage(nextProps.page + 1);
+    this.setState({
+      activePage: nextActivePage,
+      visiblePages: this.filterPages(nextVisiblePages, nextProps.pages),
+    });
+
+    nextActivePage !== this.state.activePage &&
+      this.props.onPageChange!(nextProps.page);
   }
 
   filterPages = (visiblePages: number[], totalPages: number) => {


### PR DESCRIPTION
Changing componentWillReceiveProps to set the active page and visible pages in a single setState.  Previously, the visible pages were getting set in the if block to what they should be with nextprops.pages, but when this.changePage was called, visiblePages would get reset back to what it was with the current props.
