### PR TITLE
added outline for the link (EDGE Issue)

### DIFF
--- a/src/Typography/Link/Link.component.tsx
+++ b/src/Typography/Link/Link.component.tsx
@@ -48,6 +48,7 @@ const SLink = styled.a`
   text-decoration: ${(props: Props) =>
     props.theme.typography.link.textDecoration};
   display: inline-block;
+  outline: none;
   &:hover,
   &:focus {
     color: ${(props: Props) => props.theme.typography.link.hover.color};


### PR DESCRIPTION
Added css rule
`outline: none` for the link

This will solve issue in the EDGE (for the clicked link)