### PR TITLE
Release 1.5.15 (2020-04-22)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 1.5.15 (2020-04-22)
+
+- [681](https://github.com/technekes/cast-ui/pull/681): Change overflow value to visible as default in ModalBody -
+  [@bankai254](https://github.com/bankai254)
+- [680](https://github.com/technekes/cast-ui/pull/680): Remove non used css from font.css -
+  [@hamholla]
+
 ## 1.5.14 (2020-04-15)
 
 - [677](https://github.com/technekes/cast-ui/pull/677): Add Azure theme -

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tkxs/cast-ui",
-  "version": "1.5.14",
+  "version": "1.5.15",
   "author": "tkxs",
   "description": "React component library for the TKXS design system",
   "license": "MIT",

--- a/src/Modal/Modal.component.tsx
+++ b/src/Modal/Modal.component.tsx
@@ -120,7 +120,7 @@ const ModalBodyDiv = styled.div`
   position: relative;
   height: 100%;
   overflow-y: ${(props: any) =>
-    props.modalSize === 'full' ? 'scroll' : 'auto'};
+    props.modalSize === 'full' ? 'scroll' : 'visible'};
   color: ${(props: any) => props.theme.modal.body.color};
 `;
 


### PR DESCRIPTION
## 1.5.15 (2020-04-22)

- [681](https://github.com/technekes/cast-ui/pull/681): Change overflow value to visible as default in ModalBody
- [680](https://github.com/technekes/cast-ui/pull/680): Remove non used css from font.css