### PR TITLE
Revert the change made to the Modal Body overflow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 1.5.16 (2020-04-23)
+
+- [684](https://github.com/technekes/cast-ui/pull/684): Revert the change made to the Modal Body overflow -
+  [@bankai254](https://github.com/bankai254)
+
 ## 1.5.15 (2020-04-22)
 
 - [681](https://github.com/technekes/cast-ui/pull/681): Change overflow value to visible as default in ModalBody -

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tkxs/cast-ui",
-  "version": "1.5.15",
+  "version": "1.5.16",
   "author": "tkxs",
   "description": "React component library for the TKXS design system",
   "license": "MIT",

--- a/src/Modal/Modal.component.tsx
+++ b/src/Modal/Modal.component.tsx
@@ -120,7 +120,7 @@ const ModalBodyDiv = styled.div`
   position: relative;
   height: 100%;
   overflow-y: ${(props: any) =>
-    props.modalSize === 'full' ? 'scroll' : 'visible'};
+    props.modalSize === 'full' ? 'scroll' : 'auto'};
   color: ${(props: any) => props.theme.modal.body.color};
 `;
 


### PR DESCRIPTION
PR #681 Introduced a change to the `overflow` value of the *ModalBody* which have presented issues that require going back to the drawing board.

This is reverting that.