### PR TITLE
feat(cobalt theme): add prop brandTitle to cobalt

### DIFF
--- a/src/themes/cobalt.ts
+++ b/src/themes/cobalt.ts
@@ -716,6 +716,7 @@ export const cobaltTheme = {
     borderTop: '',
     borderBottom: '',
     color: cobaltColors.drk800,
+    brandFont: '"Gilroy-Regular", "Open Sans", arial, sans-serif',
   },
   tabnav: {
     background: cobaltColors.highlight200,

--- a/src/themes/cobalt.ts
+++ b/src/themes/cobalt.ts
@@ -234,6 +234,7 @@ export const cobaltTheme = {
     },
   },
   typography: {
+    brandFont: '"Gilroy-Regular", "Open Sans", arial, sans-serif',
     fontFamily: 'Roboto, Helvetica, arial, sans-serif',
     secondaryFontFamily: '',
     fontSize: '14px',
@@ -716,7 +717,6 @@ export const cobaltTheme = {
     borderTop: '',
     borderBottom: '',
     color: cobaltColors.drk800,
-    brandFont: '"Gilroy-Regular", "Open Sans", arial, sans-serif',
   },
   tabnav: {
     background: cobaltColors.highlight200,

--- a/src/themes/falu.ts
+++ b/src/themes/falu.ts
@@ -241,6 +241,7 @@ export const faluTheme = {
     },
   },
   typography: {
+    brandFont: 'Roboto, "Open Sans", arial, sans-serif',
     fontFamily: 'Roboto, "Open Sans", arial, sans-serif',
     secondaryFontFamily: '',
     fontSize: '14px',


### PR DESCRIPTION
adding prop brandTitle to cobalt to make it cleaner when using custom fonts by relying on the theme
config

2963