### PR TITLE
fix(Select): close menu when clicking external input elements

### DIFF
--- a/src/Select/Select.component.tsx
+++ b/src/Select/Select.component.tsx
@@ -432,11 +432,6 @@ export const CustomSelect: React.FC<SelectProps> = (props) => {
         return;
       }
       
-      // Check if the target is an input element (could be the search input)
-      if (target.tagName === 'INPUT') {
-        return;
-      }
-      
       // Check if the click is within the react-select menu or menu portal
       // If so, don't close - let react-select handle it
       if (target.closest('.react-select__menu') || target.closest('.react-select__menu-portal')) {


### PR DESCRIPTION
The removed code (if (target.tagName === 'INPUT') { return; }) was a redundant guard that was accidentally too broad. It was intended to protect the filter input inside the dropdown from closing the menu, but that input already calls e.stopPropagation() on mousedown — so the document-level handler never fires for it anyway.