### PR TITLE
fix(Modal): remove default blur effect from modal

### DIFF
--- a/src/Modal/Modal.component.tsx
+++ b/src/Modal/Modal.component.tsx
@@ -67,7 +67,7 @@ export interface ModalProps extends ReactModalProps {
   disableCloseIcon: boolean;
   /**
    * adds blur effect at the bottom
-   * @default true
+   * @default false
    **/
   blurEffect?: boolean;
 }
@@ -198,7 +198,7 @@ const ModalFooterDiv = styled.div<Partial<ModalProps>>`
 const defaultProps = {
   modalSize: 'md',
   disableCloseIcon: false,
-  blurEffect: true,
+  blurEffect: false,
   theme: Themes.canopyTheme,
 } satisfies Partial<ModalProps>;
 


### PR DESCRIPTION
Here are the changes made in `Modal.component.tsx`:

- __Update the JSDoc comment__ for `blurEffect` prop: change `@default true` → `@default false` so the documentation reflects the new default
- __Update `defaultProps`__: change `blurEffect: true` → `blurEffect: false` so the blur effect is no longer shown by default on any Modal
